### PR TITLE
Update TextureCache.java

### DIFF
--- a/PD-classes/src/com/watabou/gltextures/TextureCache.java
+++ b/PD-classes/src/com/watabou/gltextures/TextureCache.java
@@ -37,7 +37,8 @@ public class TextureCache {
 		} else {
 
 			final Pixmap pixmap = new Pixmap(1, 1, Pixmap.Format.RGBA8888);
-			pixmap.setColor(color);
+			// In the rest of the code ARGB is used
+			pixmap.setColor( (color << 8) | (color >>> 24) );
 			pixmap.fill();
 			GdxTexture bmp = new GdxTexture( pixmap );
 


### PR DESCRIPTION
In "createSolid" method "color" parameter should be recoded from ARGB to RGBA (that is used in Pixmap)
