### PR TITLE
Shortcuts

### DIFF
--- a/PD-classes/src/com/watabou/input/PDInputProcessor.java
+++ b/PD-classes/src/com/watabou/input/PDInputProcessor.java
@@ -28,23 +28,43 @@ public class PDInputProcessor implements InputProcessor {
 	public static Signal<Key> eventKey = new Signal<>(true);
 	public static Signal<Touch> eventTouch = new Signal<>(true);
 	public static HashMap<Integer, Touch> pointers = new HashMap<>();
+	
+	public static boolean modifier = false;
 
 	@Override
 	public boolean keyDown(int keycode) {
-		if (keycode == Input.Keys.VOLUME_DOWN || keycode == Input.Keys.VOLUME_UP) {
+		switch (keycode) {
+		
+		case Input.Keys.VOLUME_DOWN:
+		case Input.Keys.VOLUME_UP:
 			return false;
+			
+		case Input.Keys.CONTROL_LEFT:
+		case Input.Keys.CONTROL_RIGHT:
+			modifier = true;
+			
+		default:
+			eventKey.dispatch( new Key( keycode, true ) );
+			return true;
 		}
-		eventKey.dispatch(new Key(keycode, true));
-		return true;
 	}
 
 	@Override
 	public boolean keyUp(int keycode) {
-		if (keycode == Input.Keys.VOLUME_DOWN || keycode == Input.Keys.VOLUME_UP) {
+		switch (keycode) {
+		
+		case Input.Keys.VOLUME_DOWN:
+		case Input.Keys.VOLUME_UP:
 			return false;
+			
+		case Input.Keys.CONTROL_LEFT:
+		case Input.Keys.CONTROL_RIGHT:
+			modifier = false;
+			
+		default:
+			eventKey.dispatch( new Key( keycode, false ) );
+			return true;
 		}
-		eventKey.dispatch(new Key(keycode, false));
-		return true;
 	}
 
 	@Override

--- a/core/src/com/watabou/pixeldungeon/scenes/CellSelector.java
+++ b/core/src/com/watabou/pixeldungeon/scenes/CellSelector.java
@@ -92,12 +92,14 @@ public class CellSelector extends TouchArea {
 				x = 1;
 				y = 1;
 				break;
+			case Input.Keys.ENTER:
+				break;
 			default:
 				handled = false;
 				break;
 		}
 
-		if (x != 0 || y != 0) {
+		if (handled) {
 			Point point = DungeonTilemap.tileToPoint(Dungeon.hero.pos);
 			point.x += x;
 			point.y += y;

--- a/core/src/com/watabou/pixeldungeon/ui/DangerIndicator.java
+++ b/core/src/com/watabou/pixeldungeon/ui/DangerIndicator.java
@@ -17,6 +17,8 @@
  */
 package com.watabou.pixeldungeon.ui;
 
+import com.badlogic.gdx.Input;
+import com.watabou.input.PDInputProcessor;
 import com.watabou.noosa.BitmapText;
 import com.watabou.noosa.Camera;
 import com.watabou.noosa.Image;
@@ -100,5 +102,15 @@ public class DangerIndicator extends Tag {
 		
 		Camera.main.target = null;
 		Camera.main.focusOn( target.sprite );
+	}
+	
+	@Override
+	protected boolean onKeyUp( PDInputProcessor.Key key ) {
+		if (visible && key.code == Input.Keys.TAB) {
+			onClick();
+			return true;
+		} else {
+			return false;
+		}
 	}
 }

--- a/core/src/com/watabou/pixeldungeon/ui/QuickSlot.java
+++ b/core/src/com/watabou/pixeldungeon/ui/QuickSlot.java
@@ -17,6 +17,7 @@
  */
 package com.watabou.pixeldungeon.ui;
 
+import com.watabou.input.PDInputProcessor;
 import com.watabou.noosa.Image;
 import com.watabou.noosa.ui.Button;
 import com.watabou.pixeldungeon.Dungeon;
@@ -68,6 +69,11 @@ public class QuickSlot extends Button implements WndBag.Listener {
 		slot = new ItemSlot() {
 			@Override
 			protected void onClick() {
+				if (PDInputProcessor.modifier) {
+					onLongClick();
+					return;
+				}
+				
 				if (targeting) {
 					GameScene.handleCell( lastTarget.pos );
 				} else {

--- a/core/src/com/watabou/pixeldungeon/ui/StatusPane.java
+++ b/core/src/com/watabou/pixeldungeon/ui/StatusPane.java
@@ -17,6 +17,7 @@
  */
 package com.watabou.pixeldungeon.ui;
 
+import com.badlogic.gdx.Input;
 import com.watabou.input.PDInputProcessor;
 import com.watabou.noosa.BitmapText;
 import com.watabou.noosa.Camera;
@@ -33,7 +34,9 @@ import com.watabou.pixeldungeon.items.keys.IronKey;
 import com.watabou.pixeldungeon.scenes.GameScene;
 import com.watabou.pixeldungeon.scenes.PixelScene;
 import com.watabou.pixeldungeon.sprites.HeroSprite;
+import com.watabou.pixeldungeon.windows.WndCatalogus;
 import com.watabou.pixeldungeon.windows.WndHero;
+import com.watabou.pixeldungeon.windows.WndJournal;
 
 public class StatusPane extends Component {
 	
@@ -72,7 +75,27 @@ public class StatusPane extends Component {
 					Camera.main.focusOn( sprite );
 				}
 				GameScene.show( new WndHero() );
-			};			
+			};	
+
+			@Override
+			public boolean onKeyUp(PDInputProcessor.Key key) {
+				boolean handled = true;
+				switch (key.code) {
+				case Input.Keys.H:
+					onClick( null );
+					break;
+				case Input.Keys.C:
+					GameScene.show( new WndCatalogus() );
+					break;
+				case Input.Keys.J:
+					GameScene.show( new WndJournal() );
+					break;
+				default:
+					handled = false;
+					break;
+				}
+				return handled;
+			}			
 		} );
 		
 		avatar = HeroSprite.avatar( Dungeon.hero.heroClass, lastTier );

--- a/core/src/com/watabou/pixeldungeon/ui/Toolbar.java
+++ b/core/src/com/watabou/pixeldungeon/ui/Toolbar.java
@@ -69,6 +69,7 @@ public class Toolbar extends Component {
 	protected void createChildren() {
 		
 		add( btnWait = new Tool( 0, 7, 20, 24 ) {
+			
 			@Override
 			protected void onClick() {
 				restOneTurn();

--- a/core/src/com/watabou/pixeldungeon/ui/Toolbar.java
+++ b/core/src/com/watabou/pixeldungeon/ui/Toolbar.java
@@ -198,9 +198,6 @@ public class Toolbar extends Component {
 					case Input.Keys.I:
 						showBackpack();
 						break;
-					case Input.Keys.C:
-						showCatalogus();
-						break;
 					default:
 						handled = false;
 						break;

--- a/core/src/com/watabou/pixeldungeon/ui/Toolbar.java
+++ b/core/src/com/watabou/pixeldungeon/ui/Toolbar.java
@@ -72,7 +72,11 @@ public class Toolbar extends Component {
 			
 			@Override
 			protected void onClick() {
-				restOneTurn();
+				if (PDInputProcessor.modifier) {
+					restFull();
+				} else {
+					restOneTurn();
+				}
 			};
 			protected boolean onLongClick() {
 				restFull();
@@ -84,10 +88,11 @@ public class Toolbar extends Component {
 				boolean handled = true;
 				switch (key.code) {
 					case Input.Keys.SPACE:
-						restOneTurn();
-						break;
-					case Input.Keys.F:
-						restFull();
+						if (PDInputProcessor.modifier) {
+							restFull();
+						} else {
+							restOneTurn();
+						}
 						break;
 					default:
 						handled = false;

--- a/core/src/com/watabou/pixeldungeon/windows/WndSettings.java
+++ b/core/src/com/watabou/pixeldungeon/windows/WndSettings.java
@@ -85,6 +85,8 @@ public class WndSettings extends Window {
 				}
 			}.setRect( btnZoomOut.right(), 0, WIDTH - btnZoomIn.width() - btnZoomOut.width(), BTN_HEIGHT ) );
 			
+			updateEnabled();
+			
 		} else {
 			
 			CheckBox btnScaleUp = new CheckBox( TXT_SCALE_UP ) {


### PR DESCRIPTION
Just some additional keyboard shortcuts:
- TAB for cycling through visible enemies (= clicking "danger indicator")
- ENTER for picking up things and the like (= clicking hero's current position)
- H for displaying hero's stats
- J for displaying the Journal
- C for displaying the Catalogus (now it's handled in StatusPane, not in Toolbar)

Also a new static boolean field "modifier" was added to PDInputProcessor for easy checking if Control key is pressed. The implementation is not entirely correct, I'll try to fix it later. Ctrl+click can be used for changing an item in quickslot.
