### PR TITLE
More shortcuts

### DIFF
--- a/core/src/com/watabou/pixeldungeon/scenes/CellSelector.java
+++ b/core/src/com/watabou/pixeldungeon/scenes/CellSelector.java
@@ -19,6 +19,7 @@ package com.watabou.pixeldungeon.scenes;
 
 import com.badlogic.gdx.Input;
 import com.watabou.input.PDInputProcessor;
+import com.watabou.noosa.Camera;
 import com.watabou.noosa.TouchArea;
 import com.watabou.pixeldungeon.Dungeon;
 import com.watabou.pixeldungeon.DungeonTilemap;
@@ -57,6 +58,19 @@ public class CellSelector extends TouchArea {
 
 	@Override
 	public boolean onKeyDown(PDInputProcessor.Key key) {
+
+        switch (key.code) {
+        case Input.Keys.PLUS:
+            zoom( Camera.main.zoom + 1 );
+            return true;
+        case Input.Keys.MINUS:
+            zoom( Camera.main.zoom - 1 );
+            return true;
+        case Input.Keys.SLASH:
+            zoom( PixelScene.defaultZoom );
+            return true;
+        }
+
 		boolean handled = true;
 		int x = 0, y = 0;
 		switch (key.code) {
@@ -108,6 +122,14 @@ public class CellSelector extends TouchArea {
 
 		return handled;
 	}
+
+    private void zoom( float value ) {
+     //   value = Math.round( value );
+        if (value >= PixelScene.minZoom && value <= PixelScene.maxZoom) {
+            Camera.main.zoom( value );
+            PixelDungeon.zoom((int) (value - PixelScene.defaultZoom));
+        }
+    }
 
 	public void select( int cell ) {
 		if (enabled && listener != null && cell != -1) {
@@ -172,10 +194,7 @@ public class CellSelector extends TouchArea {
 
 	@Override
 	public boolean onMouseScroll(int scroll) {
-		camera.zoom( GameMath.gate(
-				PixelScene.minZoom,
-				camera.zoom + scroll/10f,
-				PixelScene.maxZoom ) );
+		zoom( camera.zoom + scroll / 10f );
 		return true;
 	}
 

--- a/core/src/com/watabou/pixeldungeon/ui/AttackIndicator.java
+++ b/core/src/com/watabou/pixeldungeon/ui/AttackIndicator.java
@@ -19,7 +19,9 @@ package com.watabou.pixeldungeon.ui;
 
 import java.util.ArrayList;
 
+import com.badlogic.gdx.Input;
 import com.badlogic.gdx.utils.reflect.ClassReflection;
+import com.watabou.input.PDInputProcessor;
 import com.watabou.pixeldungeon.Dungeon;
 import com.watabou.pixeldungeon.actors.Char;
 import com.watabou.pixeldungeon.actors.mobs.Mob;
@@ -154,6 +156,16 @@ public class AttackIndicator extends Tag {
 			Dungeon.hero.handle( lastTarget.pos );
 		}
 	}
+
+    @Override
+    protected boolean onKeyUp( PDInputProcessor.Key key ) {
+        if (key.code == Input.Keys.A) {
+            onClick();
+            return true;
+        } else {
+            return false;
+        }
+    }
 	
 	public static void target( Char target ) {
 		lastTarget = (Mob)target;

--- a/core/src/com/watabou/pixeldungeon/ui/QuickSlot.java
+++ b/core/src/com/watabou/pixeldungeon/ui/QuickSlot.java
@@ -17,6 +17,7 @@
  */
 package com.watabou.pixeldungeon.ui;
 
+import com.badlogic.gdx.Input;
 import com.watabou.input.PDInputProcessor;
 import com.watabou.noosa.Image;
 import com.watabou.noosa.ui.Button;
@@ -98,6 +99,16 @@ public class QuickSlot extends Button implements WndBag.Listener {
 			protected void onTouchUp() {
 				icon.resetColor();
 			}
+
+            @Override
+            protected boolean onKeyUp( PDInputProcessor.Key key ) {
+                if (key.code == Input.Keys.Q) {
+                    onClick();
+                    return true;
+                } else {
+                    return false;
+                }
+            }
 		};
 		add( slot );
 		
@@ -129,6 +140,16 @@ public class QuickSlot extends Button implements WndBag.Listener {
 		GameScene.selectItem( this, WndBag.Mode.QUICKSLOT, TXT_SELECT_ITEM );
 		return true;
 	}
+
+    @Override
+    protected boolean onKeyUp( PDInputProcessor.Key key ) {
+        if (key.code == Input.Keys.Q) {
+            onLongClick();
+            return true;
+        } else {
+            return false;
+        }
+    }
 	
 	@SuppressWarnings("unchecked")
 	private static Item select() {

--- a/core/src/com/watabou/pixeldungeon/ui/Toolbar.java
+++ b/core/src/com/watabou/pixeldungeon/ui/Toolbar.java
@@ -189,8 +189,14 @@ public class Toolbar extends Component {
 			private GoldIndicator gold;
 			@Override
 			protected void onClick() {
-				showBackpack();
+                if (PDInputProcessor.modifier) {
+                    showCatalogus();
+                } else {
+                    showBackpack();
+                }
 			}
+
+            @Override
 			protected boolean onLongClick() {
 				showCatalogus();
 				return true;
@@ -201,7 +207,11 @@ public class Toolbar extends Component {
 				boolean handled = true;
 				switch (key.code) {
 					case Input.Keys.I:
-						showBackpack();
+                        if (PDInputProcessor.modifier) {
+                            showCatalogus();
+                        } else {
+                            showBackpack();
+                        }
 						break;
 					default:
 						handled = false;
@@ -275,49 +285,7 @@ public class Toolbar extends Component {
 	private static CellSelector.Listener informer = new CellSelector.Listener() {
 		@Override
 		public void onSelect( Integer cell ) {
-			
-			if (cell == null) {
-				return;
-			}
-			
-			if (cell < 0 || cell > Level.LENGTH || (!Dungeon.level.visited[cell] && !Dungeon.level.mapped[cell])) {
-				GameScene.show( new WndMessage( "You don't know what is there." ) ) ;
-				return;
-			}
-			
-			if (!Dungeon.visible[cell]) {
-				GameScene.show( new WndInfoCell( cell ) );
-				return;
-			}
-			
-			if (cell == Dungeon.hero.pos) {
-				GameScene.show( new WndHero() );
-				return;
-			}
-			
-			Mob mob = (Mob)Actor.findChar( cell );
-			if (mob != null) {
-				GameScene.show( new WndInfoMob( mob ) );
-				return;
-			}
-			
-			Heap heap = Dungeon.level.heaps.get( cell );
-			if (heap != null) {
-				if (heap.type == Heap.Type.FOR_SALE && heap.size() == 1 && heap.peek().price() > 0) {
-					GameScene.show( new WndTradeItem( heap, false ) );
-				} else {
-					GameScene.show( new WndInfoItem( heap ) );
-				}
-				return;
-			}
-			
-			Plant plant = Dungeon.level.plants.get( cell );
-			if (plant != null) {
-				GameScene.show( new WndInfoPlant( plant ) );
-				return;
-			}
-			
-			GameScene.show( new WndInfoCell( cell ) );
+            GameScene.examineCell( cell );
 		}	
 		@Override
 		public String prompt() {

--- a/core/src/com/watabou/pixeldungeon/windows/WndBag.java
+++ b/core/src/com/watabou/pixeldungeon/windows/WndBag.java
@@ -18,6 +18,7 @@
 package com.watabou.pixeldungeon.windows;
 
 import com.watabou.gltextures.TextureCache;
+import com.watabou.input.PDInputProcessor;
 import com.watabou.noosa.BitmapText;
 import com.watabou.noosa.ColorBlock;
 import com.watabou.noosa.Image;
@@ -373,8 +374,12 @@ public class WndBag extends WndTabbed {
 				listener.onSelect( item );
 				
 			} else {
-				
-				WndBag.this.add( new WndItem( WndBag.this, item ) );
+
+                if (PDInputProcessor.modifier) {
+                    onLongClick();
+                } else {
+                    WndBag.this.add(new WndItem(WndBag.this, item));
+                }
 				
 			}
 		}
@@ -383,7 +388,7 @@ public class WndBag extends WndTabbed {
 		protected boolean onLongClick() {
 			if (listener == null && item.defaultAction != null) {
 				hide();
-				Dungeon.quickslot = item instanceof Wand ? item : item.getClass();
+				Dungeon.quickslot = item.stackable ? item.getClass() : item;
 				QuickSlot.refresh();
 				return true;
 			} else {

--- a/core/src/com/watabou/pixeldungeon/windows/WndHero.java
+++ b/core/src/com/watabou/pixeldungeon/windows/WndHero.java
@@ -19,8 +19,10 @@ package com.watabou.pixeldungeon.windows;
 
 import java.util.Locale;
 
+import com.badlogic.gdx.Input;
 import com.watabou.gltextures.SmartTexture;
 import com.watabou.gltextures.TextureCache;
+import com.watabou.input.PDInputProcessor;
 import com.watabou.noosa.BitmapText;
 import com.watabou.noosa.Group;
 import com.watabou.noosa.Image;
@@ -89,8 +91,24 @@ public class WndHero extends WndTabbed {
 		
 		select( 0 );
 	}
-	
-	private class StatsTab extends Group {
+
+    @Override
+    protected void onKeyDown( PDInputProcessor.Key key ) {
+        switch (key.code) {
+        case Input.Keys.C:
+            hide();
+            GameScene.show( new WndCatalogus() );
+            break;
+        case Input.Keys.J:
+            hide();
+            GameScene.show( new WndJournal() );
+            break;
+        default:
+            super.onKeyDown( key );
+        }
+    }
+
+    private class StatsTab extends Group {
 		
 		private static final String TXT_TITLE		= "Level %d %s";
 		private static final String TXT_CATALOGUS	= "Catalogus";


### PR DESCRIPTION
- A - attack
- Q - use item in quickslot
- Ctrl+Q - select item for quickslot
- Ctrl+I - show Catalogus
- Ctrl+click on a map - examine
- \+ - / - zoom in, zoom out, default zoom
