### PR TITLE
Zoom in with '=' in addition to '+', so holding shift isn't required

### DIFF
--- a/core/src/com/watabou/pixeldungeon/scenes/CellSelector.java
+++ b/core/src/com/watabou/pixeldungeon/scenes/CellSelector.java
@@ -62,6 +62,7 @@ public class CellSelector extends TouchArea {
 
         switch (key.code) {
         case Input.Keys.PLUS:
+        case Input.Keys.EQUALS:
             zoom( camera.zoom + 1 );
             return true;
         case Input.Keys.MINUS:


### PR DESCRIPTION
For some reason after the update to the zoom system was merged, I was able to _zoom out_ with the **minus key** but not _zoom in_ with the **plus key**. I decided to make the **equals key** _zoom in_ too so I could use that, and because it seems intuitive to press the key beside the **minus key** to perform the behaviour opposite to that of the **minus key**. After doing so however, I found both that the **minus key** and **equals key** zoomed out and in nicely, but that the **plus key** now worked as well (no idea why though).

In case the **plus key** works perfectly fine on your own configuration and you were curious, I'm using an up-to-date **Arch Linux** system with **jre8-openjdk**.

Cheers!
