### PR TITLE
smooth zoom

### DIFF
--- a/PD-classes/src/com/watabou/input/PDInputProcessor.java
+++ b/PD-classes/src/com/watabou/input/PDInputProcessor.java
@@ -28,7 +28,9 @@ public abstract class PDInputProcessor implements InputProcessor {
 	public static Signal<Touch> eventTouch = new Signal<>(true);
 	public static Signal<PDMouseEvent> eventMouse = new Signal<>(true);
 	public static IntMap<Touch> pointers = new IntMap<>();
-	
+
+    public static final int MODIFIER_KEY    = Input.Keys.CONTROL_LEFT;
+
 	public static boolean modifier = false;
 
 	@Override
@@ -39,8 +41,7 @@ public abstract class PDInputProcessor implements InputProcessor {
 		case Input.Keys.VOLUME_UP:
 			return false;
 			
-		case Input.Keys.CONTROL_LEFT:
-		case Input.Keys.CONTROL_RIGHT:
+		case MODIFIER_KEY:
 			modifier = true;
 			
 		default:
@@ -57,8 +58,7 @@ public abstract class PDInputProcessor implements InputProcessor {
 		case Input.Keys.VOLUME_UP:
 			return false;
 			
-		case Input.Keys.CONTROL_LEFT:
-		case Input.Keys.CONTROL_RIGHT:
+		case MODIFIER_KEY:
 			modifier = false;
 			
 		default:

--- a/core/src/com/watabou/pixeldungeon/scenes/CellSelector.java
+++ b/core/src/com/watabou/pixeldungeon/scenes/CellSelector.java
@@ -32,13 +32,15 @@ public class CellSelector extends TouchArea {
 	
 	public boolean enabled;
 
-	private float mouseZoom;
+    private float mouseZoom;
 	
 	private float dragThreshold;
 	
 	public CellSelector( DungeonTilemap map ) {
 		super( map );
 		camera = map.camera();
+
+        mouseZoom = camera.zoom;
 		
 		dragThreshold = PixelScene.defaultZoom * DungeonTilemap.SIZE / 2;
 	}
@@ -125,12 +127,24 @@ public class CellSelector extends TouchArea {
 		return handled;
 	}
 
-    private void zoom( float value ) {
-     //   value = Math.round( value );
-        if (value >= PixelScene.minZoom && value <= PixelScene.maxZoom) {
-            camera.zoom( value );
-            PixelDungeon.zoom((int) (value - PixelScene.defaultZoom));
+    @Override
+    public boolean onKeyUp( PDInputProcessor.Key key ) {
+        switch (key.code) {
+		case PDInputProcessor.MODIFIER_KEY:
+			mouseZoom = zoom( Math.round( mouseZoom ) );
+			return true;
+		default:
+			return false;
         }
+    }
+
+    private float zoom( float value ) {
+
+        value = GameMath.gate( PixelScene.minZoom, value, PixelScene.maxZoom );
+        PixelDungeon.zoom((int) (value - PixelScene.defaultZoom));
+        camera.zoom( value );
+
+        return value;
     }
 
 	public void select( int cell ) {
@@ -196,19 +210,13 @@ public class CellSelector extends TouchArea {
 
 	@Override
 	public boolean onMouseScroll(int scroll) {
-		mouseZoom -= scroll / 10f;
-		if (mouseZoom < 0) {
-			do {
-				mouseZoom += 1;
-			} while (mouseZoom < 0);
-			zoom( camera.zoom - 1 );
-		} else if (mouseZoom > 1) {
-			do {
-				mouseZoom -= 1;
-			} while (mouseZoom > 1);
-			zoom( camera.zoom + 1 );
-		}
-		return true;
+        mouseZoom -= scroll / 3f;
+        if (PDInputProcessor.modifier) {
+            mouseZoom = zoom( mouseZoom );
+        } else {
+            zoom( Math.round( mouseZoom ) );
+        }
+        return true;
 	}
 
 	@Override


### PR DESCRIPTION
I tried to implement on desktop something similar to smooth pinch zooming on mobiles:
- When the modifier key (`Control`) is not pressed everything works as before
- When the modifier key is held down the zoom factor can be set to a fractional value. Releasing the modifier key sets the zoom factor to the nearest integer value.
