### PR TITLE
Fixed NPE when clicking outside game window and then returning back

### DIFF
--- a/desktop/src/com/watabou/pd/desktop/DesktopInputProcessor.java
+++ b/desktop/src/com/watabou/pd/desktop/DesktopInputProcessor.java
@@ -118,8 +118,13 @@ public class DesktopInputProcessor extends PDInputProcessor {
 
 	@Override
 	public boolean touchUp(int screenX, int screenY, int pointer, int button) {
-		eventTouch.dispatch(pointers.remove(button).up());
-		return true;
+		Touch touch = pointers.remove(button);
+		if(touch != null) {
+			eventTouch.dispatch(touch.up());
+			return true;
+		}
+
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
Hi, I've found a bug (in Ubuntu, but probably actual for other OSes): when the game is running, you can click somewhere outside the window (e.g. on volume control, but the window must be on screen during these operations, not hidden) and then when you return back to game (click inside game window), you'll catch `NullPointerException` with crash, because `pointers` map at this moment is empty, so `up()` method is not acceptable.

```
Exception in thread "LWJGL Application" java.lang.NullPointerException
    at com.watabou.pd.desktop.DesktopInputProcessor.touchUp(DesktopInputProcessor.java:121)
    at com.badlogic.gdx.backends.lwjgl.LwjglInput.processEvents(LwjglInput.java:326)
    at com.badlogic.gdx.backends.lwjgl.LwjglApplication.mainLoop(LwjglApplication.java:199)
    at com.badlogic.gdx.backends.lwjgl.LwjglApplication$1.run(LwjglApplication.java:114)
```

This pull request contains a patch/proposal to fix this defect.
